### PR TITLE
feat(network): add deprecation notice to static-patch crates

### DIFF
--- a/network/classic/Cargo.toml
+++ b/network/classic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm-network-classic"
 version = "0.11.0-beta.0"
-description = "Ethereum Classic patches for SputnikVM."
+description = "Ethereum Classic patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/etclabscore/sputnikvm"

--- a/network/ellaism/Cargo.toml
+++ b/network/ellaism/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm-network-ellaism"
 version = "0.11.0-beta.0"
-description = "Ellaism patches for SputnikVM."
+description = "Ellaism patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/etclabscore/sputnikvm"

--- a/network/expanse/Cargo.toml
+++ b/network/expanse/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm-network-expanse"
 version = "0.11.0-beta.0"
-description = "Expanse patches for SputnikVM."
+description = "Expanse patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/etclabscore/sputnikvm"

--- a/network/foundation/Cargo.toml
+++ b/network/foundation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm-network-foundation"
 version = "0.11.0-beta.0"
-description = "Ethereum patches for SputnikVM."
+description = "Ethereum patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/etclabscore/sputnikvm"

--- a/network/musicoin/Cargo.toml
+++ b/network/musicoin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm-network-musicoin"
 version = "0.11.0-beta.0"
-description = "Musicoin patches for SputnikVM."
+description = "Musicoin patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/etclabscore/sputnikvm"

--- a/network/ubiq/Cargo.toml
+++ b/network/ubiq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "evm-network-ubiq"
 version = "0.11.0-beta.0"
-description = "Ubiq patches for SputnikVM."
+description = "Ubiq patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 repository = "https://github.com/etclabscore/sputnikvm"


### PR DESCRIPTION
This PR adds a soft deprecation notice for the network crates, in order to motivate users switch to `evm-network`.

I also propose to discontinue the support of every network crate except the `evm-network-classic` and `evm-network-foundation`, that are convenient for SputnikVM sub-crates such as `regtests` and `evm-stateful`. 
