### PR TITLE
Version 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "evm"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 license = "Apache-2.0"
-authors = ["Wei Tang <hi@that.world>"]
+authors = ["Wei Tang <hi@that.world>", "Mike Lubinets <public@mersinvald.me>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 keywords = ["no_std", "ethereum"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@
 
 ## Features
 
-* **Partially verified (WIP)** - use various verification techniques to
-  partially verify the correctness of functions.
-* **Nightly** - take advantage of Rust nightly features, such as
-  compiler plugins
 * **Standalone** - can be launched as an independent process or integrated into other apps
 * **Universal** - supports different Ethereum chains, such as ETC, ETH or private ones
 * **Stateless** - only an execution environment connected to independent State storage

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
 description = "SputnikVM CLI"
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 # Since we have an explicit [[bin]] section below, we add the

--- a/gethrpc/Cargo.toml
+++ b/gethrpc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "gethrpc - provides functionality for interacting with geth's blockchain."
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]

--- a/network/classic/Cargo.toml
+++ b/network/classic/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "evm-network-classic"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "Ethereum Classic patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
-evm-precompiled-bn128 = { version = "0.11.0-beta", path = "../../precompiled/bn128", default-features = false}
-evm-precompiled-modexp = { version = "0.11.0-beta", path = "../../precompiled/modexp", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
+evm-precompiled-bn128 = { version = "0.11", path = "../../precompiled/bn128", default-features = false}
+evm-precompiled-modexp = { version = "0.11", path = "../../precompiled/modexp", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/dynamic/Cargo.toml
+++ b/network/dynamic/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "evm-network"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "Network-agnostic patches for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>, Mike Lubinets <public@mersinvald.me>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
-evm-precompiled-bn128 = { version = "0.11.0-beta", path = "../../precompiled/bn128", default-features = false}
-evm-precompiled-modexp = { version = "0.11.0-beta", path = "../../precompiled/modexp", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
+evm-precompiled-bn128 = { version = "0.11", path = "../../precompiled/bn128", default-features = false}
+evm-precompiled-modexp = { version = "0.11", path = "../../precompiled/modexp", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/ellaism/Cargo.toml
+++ b/network/ellaism/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "evm-network-ellaism"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "Ellaism patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/expanse/Cargo.toml
+++ b/network/expanse/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "evm-network-expanse"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "Expanse patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
-evm-precompiled-bn128 = { version = "0.11.0-beta", path = "../../precompiled/bn128", default-features = false}
-evm-precompiled-modexp = { version = "0.11.0-beta", path = "../../precompiled/modexp", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
+evm-precompiled-bn128 = { version = "0.11", path = "../../precompiled/bn128", default-features = false}
+evm-precompiled-modexp = { version = "0.11", path = "../../precompiled/modexp", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/foundation/Cargo.toml
+++ b/network/foundation/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "evm-network-foundation"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "Ethereum patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
-evm-precompiled-bn128 = { version = "0.11.0-beta", path = "../../precompiled/bn128", default-features = false}
-evm-precompiled-modexp = { version = "0.11.0-beta", path = "../../precompiled/modexp", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
+evm-precompiled-bn128 = { version = "0.11", path = "../../precompiled/bn128", default-features = false}
+evm-precompiled-modexp = { version = "0.11", path = "../../precompiled/modexp", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/musicoin/Cargo.toml
+++ b/network/musicoin/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "evm-network-musicoin"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "Musicoin patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
-evm-precompiled-bn128 = { version = "0.11.0-beta", path = "../../precompiled/bn128", default-features = false}
-evm-precompiled-modexp = { version = "0.11.0-beta", path = "../../precompiled/modexp", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
+evm-precompiled-bn128 = { version = "0.11", path = "../../precompiled/bn128", default-features = false}
+evm-precompiled-modexp = { version = "0.11", path = "../../precompiled/modexp", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/network/ubiq/Cargo.toml
+++ b/network/ubiq/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "evm-network-ubiq"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "Ubiq patches for SputnikVM. Deprecated and will be dropped in future releases: use evm-network instead"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
-evm-precompiled-bn128 = { version = "0.11.0-beta", path = "../../precompiled/bn128", default-features = false}
-evm-precompiled-modexp = { version = "0.11.0-beta", path = "../../precompiled/modexp", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
+evm-precompiled-bn128 = { version = "0.11", path = "../../precompiled/bn128", default-features = false}
+evm-precompiled-modexp = { version = "0.11", path = "../../precompiled/modexp", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 
 [features]

--- a/precompiled/bn128/Cargo.toml
+++ b/precompiled/bn128/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "evm-precompiled-bn128"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "bn128 precompiled contracts for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false }
+evm = { version = "0.11", path = "../..", default-features = false }
 ethereum-bigint = { version = "0.2", default-features = false }
 bn-plus = { version = "0.4" }
 

--- a/precompiled/modexp/Cargo.toml
+++ b/precompiled/modexp/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "evm-precompiled-modexp"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 description = "modexp precompiled contracts for SputnikVM."
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = "../..", default-features = false  }
+evm = { version = "0.11", path = "../..", default-features = false  }
 ethereum-bigint = { version = "0.2", default-features = false }
 num-bigint = "0.1"
 

--- a/regtests/Cargo.toml
+++ b/regtests/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 license = "Apache-2.0"
 authors = ["Stewart Mackenzie <setori88@gmail.com>", "Wei Tang <hi@that.world>"]
 description = "regtests - performs a regression test of the entire ethereum classic blockchain."
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 # Since we have an explicit [[bin]] section below, we add the

--- a/src/eval/cost.rs
+++ b/src/eval/cost.rs
@@ -1,7 +1,6 @@
 //! Cost calculation logic
 
 use bigint::{Address, Gas, M256, U256};
-use log::{debug, trace};
 
 #[cfg(not(feature = "std"))]
 use core::cmp::max;

--- a/src/eval/mod.rs
+++ b/src/eval/mod.rs
@@ -20,7 +20,6 @@ use super::errors::{CommitError, EvalOnChainError, NotSupportedError, OnChainErr
 use super::pc::Instruction;
 use super::{AccountCommitment, Context, HeaderParams, Log, Memory, Opcode, PCMut, Patch, Stack, Valids, PC};
 use bigint::{Address, Gas, M256, U256};
-use log::{debug, trace};
 
 use self::check::{check_opcode, check_static, check_support, extra_check_opcode};
 use self::cost::{gas_cost, gas_refund, gas_stipend, memory_cost, memory_gas, AddRefund};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,10 @@ extern crate secp256k1;
 #[cfg(feature = "std")]
 extern crate block;
 
+// BUG: without old-style #[macro_use] extern crate, evm-rs cannot be compiled as a dependency.
+#[macro_use]
+extern crate log;
+
 mod commit;
 pub mod errors;
 mod eval;
@@ -172,8 +176,6 @@ use core::cmp::min;
 use std::cmp::min;
 #[cfg(feature = "std")]
 use std::collections::{hash_map as map, HashSet as Set};
-
-use log::debug;
 
 #[derive(Debug, Clone, PartialEq)]
 /// VM Status

--- a/src/patch/precompiled.rs
+++ b/src/patch/precompiled.rs
@@ -128,7 +128,7 @@ impl Precompiled for ECRECPrecompiled {
 #[cfg(all(not(feature = "c-secp256k1"), not(feature = "rust-secp256k1")))]
 impl Precompiled for ECRECPrecompiled {
     fn gas_and_step(&self, _: &[u8], _: Gas) -> Result<(Gas, Rc<Vec<u8>>), RuntimeError> {
-        use errors::NotSupportedError;
+        use crate::errors::NotSupportedError;
 
         Err(RuntimeError::NotSupported(NotSupportedError::PrecompiledNotSupported))
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -22,8 +22,6 @@ use std::collections::{hash_map as map, HashSet as Set};
 #[cfg(feature = "std")]
 use std::ops::Deref;
 
-use log::{debug, trace};
-
 use super::errors::{CommitError, PreExecutionError, RequireError};
 use super::{
     AccountChange, AccountCommitment, AccountState, BlockhashState, Context, ContextVM, HeaderParams, Instruction, Log,

--- a/stateful/Cargo.toml
+++ b/stateful/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "evm-stateful"
-version = "0.11.0-beta.0"
+version = "0.11.0"
 license = "Apache-2.0"
 description = "Stateful evm-rs wrapped with tries."
 authors = ["Wei Tang <hi@that.world>"]
-repository = "https://github.com/etclabscore/sputnikvm"
+repository = "https://github.com/ethereumproject/evm-rs"
 edition = "2018"
 
 [dependencies]
-evm = { version = "0.11.0-beta", path = '..' }
-ethereum-bigint = "0.2"
-ethereum-trie = "0.3"
-ethereum-block = "0.4"
-ethereum-rlp = "0.2"
+evm = { version = "0.11", path = '..', default-features = false, features = ["std"] }
+ethereum-bigint = { version = "0.2", default-features = false, features = ["std"] }
+ethereum-trie = { version = "0.3", default-features = false }
+ethereum-block = { version = "0.4", default-features = false }
+ethereum-rlp = { version = "0.2", default-features = false, features = ["std"] }
 sha3 = "0.6"
 rand = "0.3"
 
@@ -22,4 +22,9 @@ serde_derive = "1.0"
 serde_json = "1.0"
 lazy_static = "0.2"
 ethereum-hexutil = "0.2"
-evm-network-classic = { version = "0.11.0-beta", path = "../network/classic" }
+evm-network-classic = { version = "0.11", path = "../network/classic" }
+
+[features]
+default = ["rust-secp256k1"]
+c-secp256k1 = ["evm/c-secp256k1", "ethereum-block/c-secp256k1"]
+rust-secp256k1 = ["evm/libsecp256k1", "ethereum-block/rust-secp256k1"]


### PR DESCRIPTION
# Version 0.11.0

## What's new?

### Network support

SputnikVM v0.11 passes every test in the ETH test suit making it sufficient enough to be used with the ETH network.

##### Related Pull Requests: 
 - https://github.com/ETCDEVTeam/sputnikvm/pull/337
 - https://github.com/ETCDEVTeam/sputnikvm/pull/349
 - https://github.com/ETCDEVTeam/sputnikvm/pull/352
 - https://github.com/ETCDEVTeam/sputnikvm/pull/360
 - https://github.com/ETCDEVTeam/sputnikvm/pull/364
 - https://github.com/etclabscore/evm-rs/pull/2
 - https://github.com/ethereumproject/evm-rs/pull/22
 
##### Changes:
- Byzantium opcodes implementation is tested and refined
- The following opcodes are implemented and tested:
  - SHL, SHR, SAR ([EIP-145](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-145.md))
  - CREATE2 ([EIP-1014](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1014.md))
  - EXTCODEHASH ([EIP-1052](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1052.md))
- SSTORE opcode gas metering adjustments ([EIP-1283](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1283.md))
- Number of new and pre-0.11 interpreter bugs fixed
 
### API 

SputnikVM API is now more agile then ever: the new DynamicPatch API enables the patch-based configuration 
to be performed at runtime, as opposed to static patches that were based on using the static generic types.
This change is particularly useful for multi-chain clients like [multi-geth](https://github.com/multi-geth/multi-geth) that cooperates with SputnikVM over 
an FFI boundary. Now it may configure SputnikVM feature-wise in runtime, and not rely on a pre-defined set of network and fork specific constructors.
All that with keeping overhead as low as possible and completely zero-copy!

Therefore, we recommend switching to [evm-network](https://crates.io/crates/evm-network) crate as a foundation for `Patch`-building,
`evm-network-*` crates are considered deprecated and may not be supported in the future releases.

##### Related Pull Requests:
 - https://github.com/etclabscore/evm-rs/pull/23
 - https://github.com/etclabscore/evm-rs/pull/31
 - https://github.com/ethereumproject/evm-rs/pull/36
 - https://github.com/ethereumproject/evm-rs/pull/37
 
##### Changes:
 - New [evm-network](https://crates.io/crates/evm-network) with a set of precompiled contracts and re-exports of `Patch` and `DynamicPatch` APIs.
 - Breaking changes in the `Patch` trait and related code
 
### Testing

Testing framework for the JsonTests (VMTests from ETH Test Suite) have been majorly reworked,
now it generates a separate native Rust test for each testcase in the Json files, for debugging and subset runs convenience.

##### Related Pull Requests: 
 - https://github.com/ETCDEVTeam/sputnikvm/pull/335

##### Changes: 
 - use of custom derive macro to generate tests from json files.
 - generate benchmarks using [criterion](https://github.com/bheisler/criterion.rs).
 - update the tests from foundation upstream.

### Documentation

- [Automated formatting with rustfmt](https://github.com/ethereumproject/evm-rs/blob/master/FORMATTING.md)

### Other changes

 - `rust-secp256k1` feature is enabled by default
 - Minumum Rust version updated to 1.33.0.
 - [Rust 2018 edition is enabled by default](https://github.com/etclabscore/evm-rs/pull/28).
 - [Code formatting with rustfmt and CI rules to enforce correct formatting](https://github.com/etclabscore/evm-rs/pull/29).
 - [Continuous Integration with Jenkins CI](https://github.com/etclabscore/evm-rs/pull/32).
 - General dependencies upgrade.
 - Transition back to `ethereumproject` under the name `evm-rs`.
 - Change of crate names to `evm` and `evm-*` for related projects.

### Related projects
 - `evm-ffi` received support of the `DynamicPatch` API.
 - Ethereum Classic specific APIs are `deprecated` in `evm-ffi` and are going to be removed in the future releases.

Closes #32 