### PR TITLE
Update JIT with more readable function type builder API

### DIFF
--- a/src/evmjit/compiler/evm_compiler.rs
+++ b/src/evmjit/compiler/evm_compiler.rs
@@ -4,6 +4,7 @@ use inkwell::basic_block::BasicBlock;
 use inkwell::module::Linkage::*;
 use inkwell::values::FunctionValue;
 
+use super::util::funcbuilder::*;
 use super::JITContext;
 
 pub struct MainFuncCreator {
@@ -24,7 +25,12 @@ impl MainFuncCreator {
         let main_ret_type = types_instance.get_contract_return_type();
         let arg1 = context.rt().get_ptr_type();
 
-        let main_func_type = main_ret_type.fn_type(&[arg1.into()], false);
+        let main_func_type = FunctionTypeBuilder::new(context.llvm_context())
+            .returns(main_ret_type)
+            .arg(arg1)
+            .build()
+            .unwrap();
+
         let main_func = module.add_function(name, main_func_type, Some(External));
         main_func.get_first_param().unwrap().into_pointer_value().set_name("rt");
 

--- a/src/evmjit/compiler/external_declarations.rs
+++ b/src/evmjit/compiler/external_declarations.rs
@@ -5,6 +5,7 @@ use std::cell::RefCell;
 use inkwell::module::Linkage::*;
 use inkwell::values::FunctionValue;
 
+use super::util::funcbuilder::*;
 use super::JITContext;
 
 /// Trait representing the interface to managers of LLVM function declarations.
@@ -75,9 +76,11 @@ impl<'a> ExternalFunctionManager<'a> {
         let types = self.m_context.evm_types();
         let attr_factory = self.m_context.attributes();
 
-        let malloc_fn_type = types
-            .get_word_ptr_type()
-            .fn_type(&[types.get_size_type().into()], false);
+        let malloc_fn_type = FunctionTypeBuilder::new(self.m_context.llvm_context())
+            .returns(types.get_word_ptr_type())
+            .arg(types.get_size_type())
+            .build()
+            .unwrap();
 
         let malloc_func = module.add_function("malloc", malloc_fn_type, Some(External));
 
@@ -95,7 +98,11 @@ impl<'a> ExternalFunctionManager<'a> {
         let free_ret_type = self.m_context.llvm_context().void_type();
         let arg1 = types.get_word_ptr_type();
 
-        let free_func_type = free_ret_type.fn_type(&[arg1.into()], false);
+        let free_func_type = FunctionTypeBuilder::new(self.m_context.llvm_context())
+            .returns(free_ret_type)
+            .arg(arg1)
+            .build()
+            .unwrap();
 
         let free_func = module.add_function("free", free_func_type, Some(External));
 
@@ -113,7 +120,12 @@ impl<'a> ExternalFunctionManager<'a> {
         let realloc_return_type = types.get_byte_ptr_type();
         let arg1 = types.get_byte_ptr_type();
         let arg2 = types.get_size_type();
-        let realloc_func_type = realloc_return_type.fn_type(&[arg1.into(), arg2.into()], false);
+        let realloc_func_type = FunctionTypeBuilder::new(self.m_context.llvm_context())
+            .returns(realloc_return_type)
+            .arg(arg1)
+            .arg(arg2)
+            .build()
+            .unwrap();
 
         let realloc_func = module.add_function("realloc", realloc_func_type, Some(External));
 

--- a/src/evmjit/compiler/gas_cost/mod.rs
+++ b/src/evmjit/compiler/gas_cost/mod.rs
@@ -21,6 +21,7 @@ use inkwell::IntPredicate;
 use patch::Patch;
 use util::opcode::Opcode;
 
+use super::util::funcbuilder::*;
 use super::JITContext;
 
 pub trait InstructionGasCost {
@@ -57,7 +58,14 @@ impl GasCheckFunctionCreator {
         let arg2 = types_instance.get_gas_type();
         let arg3 = types_instance.get_byte_ptr_type();
 
-        let gas_func_type = gas_func_ret_type.fn_type(&[arg1.into(), arg2.into(), arg3.into()], false);
+        let gas_func_type = FunctionTypeBuilder::new(context)
+            .returns(gas_func_ret_type)
+            .arg(arg1)
+            .arg(arg2)
+            .arg(arg3)
+            .build()
+            .unwrap();
+
         let gas_func = module.add_function(name, gas_func_type, Some(Private));
 
         let attr_factory = jitctx.attributes();

--- a/src/evmjit/compiler/gas_cost/variable_gas_cost.rs
+++ b/src/evmjit/compiler/gas_cost/variable_gas_cost.rs
@@ -202,6 +202,7 @@ fn native_log_base2(gas_val: Gas) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use evmjit::compiler::util::funcbuilder::*;
     use evmjit::compiler::evm_compiler::MainFuncCreator;
     use evmjit::compiler::{ExternalFunctionManager, DeclarationManager};
     use evmjit::compiler::intrinsics::LLVMIntrinsic;
@@ -227,7 +228,12 @@ mod tests {
         let gas_type = types_instance.get_gas_type();
 
         let i64_type = context.i64_type();
-        let fn_type = i64_type.fn_type(&[gas_type.into()], false);
+
+        let fn_type = FunctionTypeBuilder::new(context)
+            .returns(i64_type)
+            .arg(gas_type)
+            .build()
+            .unwrap();
 
         // Get declaration of ctlz
         let ctlz_decl = LLVMIntrinsic::Ctlz.get_intrinsic_declaration(jitctx, Some(enum_word_type));

--- a/src/evmjit/compiler/intrinsics.rs
+++ b/src/evmjit/compiler/intrinsics.rs
@@ -4,6 +4,7 @@ use inkwell::types::IntType;
 use inkwell::values::FunctionValue;
 use inkwell::AddressSpace;
 
+use super::util::funcbuilder::*;
 use super::JITContext;
 
 static FRAME_ADDRESS_INTRINSIC_NAME: &str = "llvm.frameaddress";
@@ -119,7 +120,12 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
                     let width_t = IntType::custom_width_int_type(int_bit_width);
                     let type_enum = BasicTypeEnum::IntType(width_t);
 
-                    let bswap_func_type = bswap_ret_type.fn_type(&[type_enum.into()], false);
+                    let bswap_func_type = FunctionTypeBuilder::new(context.llvm_context())
+                        .returns(bswap_ret_type)
+                        .arg(type_enum)
+                        .build()
+                        .unwrap();
+
                     let bswap_func = module.add_function(bswap_func_name, bswap_func_type, Some(External));
 
                     let attr_factory = context.attributes();
@@ -136,7 +142,6 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
 
                 let memset_func_name = self.to_name(arg_type);
                 let module = context.module();
-
 
                 let memset_func_found = module.get_function(memset_func_name);
                 if memset_func_found.is_some() {
@@ -158,8 +163,15 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
                     let arg2 = llvm_ctx.i8_type();
                     let arg4 = llvm_ctx.bool_type();
 
-                    let memset_func_type =
-                        memset_ret_type.fn_type(&[arg1.into(), arg2.into(), type_enum.into(), arg4.into()], false);
+                    let memset_func_type = FunctionTypeBuilder::new(llvm_ctx)
+                        .returns(memset_ret_type)
+                        .arg(arg1)
+                        .arg(arg2)
+                        .arg(type_enum)
+                        .arg(arg4)
+                        .build()
+                        .unwrap();
+
                     let memset_func = module.add_function(memset_func_name, memset_func_type, Some(External));
                     let attr_factory = context.attributes();
 
@@ -183,7 +195,12 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
                     let ctlz_ret_type = types_instance.get_word_type();
                     let arg1 = types_instance.get_word_type();
                     let arg2 = llvm_ctx.bool_type();
-                    let ctlz_func_type = ctlz_ret_type.fn_type(&[arg1.into(), arg2.into()], false);
+                    let ctlz_func_type = FunctionTypeBuilder::new(llvm_ctx)
+                        .returns(ctlz_ret_type)
+                        .arg(arg1)
+                        .arg(arg2)
+                        .build()
+                        .unwrap();
                     let ctlz_func = module.add_function(ctlz_func_name, ctlz_func_type, Some(External));
 
                     let attr_factory = context.attributes();
@@ -206,7 +223,11 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
                     let llvm_ctx = context.llvm_context();
                     let frame_addr_ret_type = llvm_ctx.i8_type().ptr_type(AddressSpace::Generic);
                     let arg1 = llvm_ctx.i32_type();
-                    let frame_addr_func_type = frame_addr_ret_type.fn_type(&[arg1.into()], false);
+                    let frame_addr_func_type = FunctionTypeBuilder::new(llvm_ctx)
+                        .returns(frame_addr_ret_type)
+                        .arg(arg1)
+                        .build()
+                        .unwrap();
                     let frame_addr_func = module.add_function(frame_addr_func_name, frame_addr_func_type, Some(External));
 
                     let attr_factory = context.attributes();
@@ -228,7 +249,11 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
                     let llvm_ctx = context.llvm_context();
                     let longjmp_ret_type = llvm_ctx.void_type();
                     let arg1 = llvm_ctx.i8_type().ptr_type(AddressSpace::Generic);
-                    let longjmp_func_type = longjmp_ret_type.fn_type(&[arg1.into()], false);
+                    let longjmp_func_type = FunctionTypeBuilder::new(llvm_ctx)
+                        .returns(longjmp_ret_type)
+                        .arg(arg1)
+                        .build()
+                        .unwrap();
                     let longjmp_func = module.add_function(longjmp_func_name, longjmp_func_type, Some(External));
 
                     let attr_factory = context.attributes();
@@ -249,7 +274,10 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
                 } else {
                     let llvm_ctx = context.llvm_context();
                     let stack_save_ret_type = llvm_ctx.i8_type().ptr_type(AddressSpace::Generic);
-                    let stack_save_func_type = stack_save_ret_type.fn_type(&[], false);
+                    let stack_save_func_type = FunctionTypeBuilder::new(llvm_ctx)
+                        .returns(stack_save_ret_type)
+                        .build()
+                        .unwrap();
                     let stack_save_func = module.add_function(stacksave_func_name, stack_save_func_type, Some(External));
 
                     let attr_factory = context.attributes();
@@ -270,7 +298,11 @@ impl LLVMIntrinsicManager for LLVMIntrinsic {
                     let llvm_ctx = context.llvm_context();
                     let setjmp_ret_type = llvm_ctx.i32_type();
                     let arg1 = llvm_ctx.i8_type().ptr_type(AddressSpace::Generic);
-                    let setjmp_func_type = setjmp_ret_type.fn_type(&[arg1.into()], false);
+                    let setjmp_func_type = FunctionTypeBuilder::new(llvm_ctx)
+                        .returns(setjmp_ret_type)
+                        .arg(arg1)
+                        .build()
+                        .unwrap();
                     let setjmp_func = module.add_function(setjmp_func_name, setjmp_func_type, Some(External));
 
                     let attr_factory = context.attributes();

--- a/src/evmjit/compiler/memory/evm_memory.rs
+++ b/src/evmjit/compiler/memory/evm_memory.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use super::super::JITContext;
+use super::super::util::funcbuilder::*;
 use super::mem_representation::MemoryRepresentation;
 use evmjit::compiler::byte_order::byte_order_swap;
 use evmjit::compiler::external_declarations::ExternalFunctionManager;
@@ -52,7 +53,16 @@ impl<'a, P: Patch> MemoryFuncDeclarationManager<'a, P> {
             let attr_factory = self.m_context.attributes();
 
             let ret_type = context.void_type();
-            let alloc_mem_fn_type = ret_type.fn_type(&[arg1.into(), arg2.into(), arg3.into(), arg4.into(), arg5.into()], false);
+            let alloc_mem_fn_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(arg1)
+                .arg(arg2)
+                .arg(arg3)
+                .arg(arg4)
+                .arg(arg5)
+                .build()
+                .unwrap();
+
             let alloc_mem_func = module.add_function("mem.allocate", alloc_mem_fn_type, Some(Private));
 
             // Function does not throw
@@ -193,7 +203,13 @@ impl<'a, P: Patch> MemoryFuncDeclarationManager<'a, P> {
             let module = self.m_context.module();
 
             let ret_type = context.void_type();
-            let mstore8_fn_type = ret_type.fn_type(&[arg1.into(), arg2.into(), arg3.into()], false);
+            let mstore8_fn_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(arg1)
+                .arg(arg2)
+                .arg(arg3)
+                .build()
+                .unwrap();
             let mstore8_func = module.add_function("mstore8", mstore8_fn_type, Some(Private));
 
             assert!(mstore8_func.get_nth_param(0).is_some());
@@ -241,7 +257,13 @@ impl<'a, P: Patch> MemoryFuncDeclarationManager<'a, P> {
             let module = self.m_context.module();
 
             let ret_type = context.void_type();
-            let mstore_fn_type = ret_type.fn_type(&[arg1.into(), arg2.into(), arg3.into()], false);
+            let mstore_fn_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(arg1)
+                .arg(arg2)
+                .arg(arg3)
+                .build()
+                .unwrap();
             let mstore_func = module.add_function("mstore", mstore_fn_type, Some(Private));
 
             assert!(mstore_func.get_nth_param(0).is_some());
@@ -282,13 +304,19 @@ impl<'a, P: Patch> MemoryFuncDeclarationManager<'a, P> {
 
     pub fn get_mload_func(&self, linear_memory: &'a MemoryRepresentation) -> FunctionValue {
         if self.m_evm_mem_load_func.borrow().is_none() {
+            let context = self.m_context.llvm_context();
             let types_instance = self.m_context.evm_types();
+
             let arg1 = self.m_context.memrep().get_ptr_type();
             let arg2 = types_instance.get_word_type();
             let ret_type = types_instance.get_word_type();
-            let mload_fn_type = ret_type.fn_type(&[arg1.into(), arg2.into()], false);
+            let mload_fn_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(arg1)
+                .arg(arg2)
+                .build()
+                .unwrap();
 
-            let context = self.m_context.llvm_context();
             let module = self.m_context.module();
 
             let mload_func = module.add_function("mload", mload_fn_type, Some(Private));

--- a/src/evmjit/compiler/memory/mem_representation.rs
+++ b/src/evmjit/compiler/memory/mem_representation.rs
@@ -18,6 +18,7 @@ use std::cell::RefCell;
 use std::ffi::CString;
 
 use super::super::JITContext;
+use evmjit::compiler::util::funcbuilder::*;
 
 #[derive(Debug)]
 
@@ -131,7 +132,13 @@ impl<'a> MemoryRepresentationFunctionManager<'a> {
             let arg1 = self.m_context.memrep().get_ptr_type();
             let arg2 = types_instance.get_size_type();
 
-            let extend_evm_mem_fn_type = ret_type.fn_type(&[arg1.into(), arg2.into()], false);
+            let extend_evm_mem_fn_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(arg1)
+                .arg(arg2)
+                .build()
+                .unwrap();
+
             let extend_evm_mem_func =
                 self.m_context
                     .module()
@@ -243,9 +250,13 @@ impl<'a> MemoryRepresentationFunctionManager<'a> {
             let types_instance = self.m_context.evm_types();
             let arg1 = self.m_context.memrep().get_ptr_type();
             let arg2 = types_instance.get_size_type();
-            let evm_mem_ptr_fn_type = types_instance
-                .get_word_ptr_type()
-                .fn_type(&[arg1.into(), arg2.into()], false);
+
+            let evm_mem_ptr_fn_type = FunctionTypeBuilder::new(self.m_context.llvm_context())
+                .returns(types_instance.get_word_ptr_type())
+                .arg(arg1)
+                .arg(arg2)
+                .build()
+                .unwrap();
 
             let evm_mem_func = self
                 .m_context

--- a/src/evmjit/compiler/runtime_functions/divmod.rs
+++ b/src/evmjit/compiler/runtime_functions/divmod.rs
@@ -8,6 +8,7 @@ use inkwell::types::IntType;
 use inkwell::types::BasicTypeEnum;
 use evmjit::compiler::intrinsics::LLVMIntrinsic;
 use evmjit::compiler::intrinsics::LLVMIntrinsicManager;
+use evmjit::compiler::util::funcbuilder::*;
 
 pub struct DivModDeclarationManager<'a> {
     m_context: &'a JITContext,
@@ -33,7 +34,13 @@ impl<'a> DivModDeclarationManager<'a> {
 
         let arg1 = func_type;
         let arg2 = func_type;
-        let divmod_func_type = ret_type.fn_type(&[arg1.into(), arg2.into()], false);
+        let divmod_func_type = FunctionTypeBuilder::new(context)
+            .returns(ret_type)
+            .arg(arg1)
+            .arg(arg2)
+            .build()
+            .unwrap();
+
         let divmod_func = module.add_function (func_name, divmod_func_type, Some(Private));
 
         // Function does not throw
@@ -190,7 +197,13 @@ impl<'a> DivModDeclarationManager<'a> {
             let word_type = self.m_context.evm_types().get_word_type();
             let ret_type = word_type;
 
-            let udiv_func_type = ret_type.fn_type(&[word_type.into(), word_type.into()], false);
+            let udiv_func_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(word_type)
+                .arg(word_type)
+                .build()
+                .unwrap();
+
             let udiv256_func = module.add_function(func_name, udiv_func_type, Some(Private));
 
             // Function does not throw
@@ -243,7 +256,13 @@ impl<'a> DivModDeclarationManager<'a> {
             let word_type = self.m_context.evm_types().get_word_type();
             let ret_type = word_type.vec_type(2);;
 
-            let sdivrem256_func_type = ret_type.fn_type(&[word_type.into(), word_type.into()], false);
+            let sdivrem256_func_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(word_type)
+                .arg(word_type)
+                .build()
+                .unwrap();
+
             let sdivrem256_func = module.add_function(func_name, sdivrem256_func_type, Some(Private));
 
             // Function does not throw
@@ -316,7 +335,13 @@ impl<'a> DivModDeclarationManager<'a> {
             let word_type = self.m_context.evm_types().get_word_type();
             let ret_type = word_type;
 
-            let sdiv_func_type = ret_type.fn_type(&[word_type.into(), word_type.into()], false);
+            let sdiv_func_type = FunctionTypeBuilder::new(context)
+                .returns(ret_type)
+                .arg(word_type)
+                .arg(word_type)
+                .build()
+                .unwrap();
+
             let sdiv256_func = module.add_function(func_name, sdiv_func_type, Some(Private));
 
             // Function does not throw


### PR DESCRIPTION
Uses the recently merged `FunctionTypeBuilder` API, which resides in `compiler::util::funcbuilder`.
A bit more verbose for tiny functions but much easier to understand/debug.